### PR TITLE
fix_int8Conv

### DIFF
--- a/runtime_lut/code/api.py
+++ b/runtime_lut/code/api.py
@@ -22,7 +22,7 @@ from lut_schema import LUTSchema, load_caffe2_op
 
 DB_DIR = '../'
 
-TO_MATCH = ['op_type', 'op_args', 'input_shapes', 'input_dtypes', 'device']
+TO_MATCH = ['op_type', 'input_shapes', 'input_dtypes', 'device', 'op_args']
 
 DTYPE_ENCODE = {
     'undefined': core.DataType.UNDEFINED,
@@ -133,6 +133,10 @@ class OpLut(object):
                 records.append(op)
 
         if records == []:
+            if op_query.get_val('op_type') == 'Int8Conv':
+                op_query.set_val('op_type', 'Int8ConvRelu')
+                return self.find_op(op_query)
+
             print('No match found in the database!')
         return records
 

--- a/runtime_lut/code/lut_schema.py
+++ b/runtime_lut/code/lut_schema.py
@@ -35,7 +35,7 @@ def load_caffe2_op(op_record, caffe2_op, input_shapes,
     op_record.set_val('op_type', caffe2_op.type)
     op_args = [arg for arg in caffe2_op.arg if arg.name not in ARGS_IGNORE]
     op_args.sort(key=lambda x: x.name)
-    op_record.set_val('op_args', [str(a) for a in op_args])
+    op_record.set_val('op_args', [str(a) for a in op_args if not 'ws_nbytes_limit' in str(a)])
     op_record.set_val('input_shapes', input_shapes)
     op_record.set_val('input_dtypes', input_dtypes)
     op_record.set_val('device', device)
@@ -89,4 +89,6 @@ class LUTSchema():
         elif isinstance(input_, dict):
             record = input_
         for k, v in record.items():
+            if k == 'op_args':
+                v = [str(a) for a in v if not 'ws_nbytes_limit' in str(a)]
             self.set_val(k, v)


### PR DESCRIPTION
We fix two issues:
1. If Int8Conv is missing, use the latency of Int8ConvRelu instead.
2. Ignore 'ws_nbytes_limit' in op_args comparison.