### PR TITLE
Update the sync batch norm implementation for sync_bn

### DIFF
--- a/mobile_cv/arch/fbnet_v2/basic_blocks.py
+++ b/mobile_cv/arch/fbnet_v2/basic_blocks.py
@@ -22,6 +22,7 @@ from mobile_cv.arch.layers import (
     NaiveSyncBatchNorm,
     NaiveSyncBatchNorm1d,
     NaiveSyncBatchNorm3d,
+    SyncBatchNormWrapper,
 )
 from torch.nn.quantized.modules import FloatFunctional
 
@@ -310,7 +311,7 @@ def build_bn(name, num_channels, zero_gamma=None, gamma_beta=None, **kwargs):
     BN_DEFAULT_MAPS = {
         # 2d
         "bn": lambda: _create_bn(nn.BatchNorm2d),
-        "sync_bn": lambda: _create_bn(NaiveSyncBatchNorm),
+        "sync_bn": lambda: _create_bn(SyncBatchNormWrapper),
         "naiveSyncBN": lambda: _create_bn(NaiveSyncBatchNorm),
         # 3d
         "bn3d": lambda: _create_bn(nn.BatchNorm3d),

--- a/mobile_cv/arch/layers/__init__.py
+++ b/mobile_cv/arch/layers/__init__.py
@@ -6,6 +6,7 @@ from .batch_norm import (
     NaiveSyncBatchNorm,
     NaiveSyncBatchNorm1d,
     NaiveSyncBatchNorm3d,
+    SyncBatchNormWrapper,
 )
 
 # isort/black has issues in processing those import
@@ -31,6 +32,7 @@ __all__ = [
     "NaiveSyncBatchNorm",
     "NaiveSyncBatchNorm1d",
     "NaiveSyncBatchNorm3d",
+    "SyncBatchNormWrapper",
     "cat",
     "interpolate",
     "ShapeSpec",

--- a/mobile_cv/arch/utils/fuse_utils.py
+++ b/mobile_cv/arch/utils/fuse_utils.py
@@ -15,6 +15,7 @@ from mobile_cv.arch.layers.batch_norm import (
     NaiveSyncBatchNorm,
     NaiveSyncBatchNorm1d,
     NaiveSyncBatchNorm3d,
+    SyncBatchNormWrapper,
 )
 
 
@@ -68,6 +69,7 @@ CONV_BN_RELU_SUPPORTED_FUSING_TYPES = {
         NaiveSyncBatchNorm,
         NaiveSyncBatchNorm1d,
         NaiveSyncBatchNorm3d,
+        SyncBatchNormWrapper,
     ],
     "relu": [nn.ReLU],
 }
@@ -82,6 +84,7 @@ SWAPPING_MODULES = {
     NaiveSyncBatchNorm: _cast_func,
     NaiveSyncBatchNorm1d: _cast_func,
     NaiveSyncBatchNorm3d: _cast_func,
+    SyncBatchNormWrapper: _cast_func,
 }
 
 


### PR DESCRIPTION
Summary:
The sync_bn batch norm has been using a non-efficient implementation NaiveSyncBatchNorm. This is because in pytorch<=1.5, nn.SyncBatchNorm had incorrect gradient when the batch size on each worker is different, so a NaiveSyncBatchNorm was implemented. This issue has been fixed in https://github.com/pytorch/pytorch/pull/36382. So we change that implementation back to the faster nn.SyncBatchNorm.

Since nn.SyncBatchNorm only has GPU implementation, for the unit tests running with single process on CPU, the original NaiveSyncBatchNorm is used.

Reviewed By: wat3rBro

Differential Revision: D35300913

