### PR TITLE
Add required example_args argument to prepare_fx and prepare_qat_fx

### DIFF
--- a/mobile_cv/arch/tests/test_fbnet_v2_quantize.py
+++ b/mobile_cv/arch/tests/test_fbnet_v2_quantize.py
@@ -86,7 +86,11 @@ class TestFBNetV2Quantize(unittest.TestCase):
         model.train()
 
         qconfig_dict = {"": torch.ao.quantization.get_default_qat_qconfig("fbgemm")}
-        model_prepared = quantize_fx.prepare_qat_fx(model, qconfig_dict)
+        example_inputs = (torch.rand(2, 3, 8, 8),)
+        model_prepared = quantize_fx.prepare_qat_fx(
+            model, qconfig_dict, example_inputs=example_inputs
+        )
+
         print(f"Prepared model {model_prepared}")
 
         # calibration

--- a/mobile_cv/arch/tests/test_fbnet_v2_res_block.py
+++ b/mobile_cv/arch/tests/test_fbnet_v2_res_block.py
@@ -94,7 +94,8 @@ class TestResBlock(unittest.TestCase):
         data = torch.zeros(1, 8, 4, 4)
 
         qconfig_dict = qu.get_qconfig_dict(model, qconfig)
-        model = prepare_fx(model, qconfig_dict)
+        example_inputs = (data,)
+        model = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
         model = convert_fx(model)
         print(model)
 

--- a/mobile_cv/arch/tests/test_utils_quantize_utils.py
+++ b/mobile_cv/arch/tests/test_utils_quantize_utils.py
@@ -361,7 +361,8 @@ class TestUtilsQuantizeUtils(unittest.TestCase):
         model = MM().eval()
         qconfig = torch.ao.quantization.get_default_qconfig("qnnpack")
         qconfig_dict = qu.get_qconfig_dict(model, qconfig)
-        model = prepare_fx(model, qconfig_dict)
+        example_inputs = (torch.rand(1, 1, 3, 3),)
+        model = prepare_fx(model, qconfig_dict, example_inputs=example_inputs)
         model = convert_fx(model)
         print(model)
 

--- a/mobile_cv/arch/utils/quantize_utils.py
+++ b/mobile_cv/arch/utils/quantize_utils.py
@@ -186,13 +186,15 @@ class PostQuantizationFX(object):
         self.qconfig = quant_cfg
         return self
 
-    def prepare(self, qconfig_dict=None):
+    def prepare(self, example_inputs, qconfig_dict=None):
         if qconfig_dict is None:
             qconfig_dict = get_qconfig_dict(self.model, self.qconfig)
         if qconfig_dict is None:
             qconfig_dict = {"": self.qconfig}
         self._prepared_model = torch.ao.quantization.quantize_fx.prepare_fx(
-            self.model, qconfig_dict
+            self.model,
+            qconfig_dict=qconfig_dict,
+            example_inputs=example_inputs,
         )
         return self
 

--- a/mobile_cv/model_zoo/tools/create_model.py
+++ b/mobile_cv/model_zoo/tools/create_model.py
@@ -140,9 +140,10 @@ def convert_int8_jit(args, model, data, folder_name="int8_jit"):
             )
         else:
             quant = qu.PostQuantizationFX(model)
+            example_inputs = tuple(data)
             quant_model = (
                 quant.set_quant_backend("default")
-                .prepare()
+                .prepare(example_inputs=example_inputs)
                 .calibrate_model([data], 1)
                 .convert_model()
             )


### PR DESCRIPTION
Summary:
FX Graph Mode Quantization needs to know whether an fx node is a floating point Tensor before it can decide whether to
insert observer/fake_quantize module or not, since we only insert observer/fake_quantize module for floating point Tensors.
Currently we have some hacks to support this by defining some rules like NON_OBSERVABLE_ARG_DICT (https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/utils.py#L496), but this approach is fragile and we do not plan to maintain it long term in the pytorch code base.

As we discussed in the design review, we'd need to ask users to provide sample args and sample keyword args
so that we can infer the type in a more robust way. This PR starts with changing the prepare_fx and prepare_qat_fx api to require user to either provide
example arguments thrugh example_inputs, Note this api doesn't support kwargs, kwargs can make https://github.com/pytorch/pytorch/pull/76496#discussion_r861230047 (comment) simpler, but
it will be rare, and even then we can still workaround with positional arguments, also torch.jit.trace(https://pytorch.org/docs/stable/generated/torch.jit.trace.html) and ShapeProp: https://github.com/pytorch/pytorch/blob/master/torch/fx/passes/shape_prop.py#L140 just have single positional args, we'll just use a single example_inputs argument for now.

If needed, we can extend the api with an optional example_kwargs. e.g. in case when there are a lot of arguments for forward and it makes more sense to
pass the arguments by keyword

BC-breaking Note:
Before:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict)

After:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 224, 224),))

Reviewed By: vkuzo, andrewor14

Differential Revision: D35984526

