### PR TITLE
move oss utils from d2go to mobile_cv

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -32,7 +32,5 @@ jobs:
           pip install -e .
 
       - name: Run pytest
-        env:
-            OSSRUN: 1
         run: |
           python -m unittest discover -v -s .

--- a/mobile_cv/common/misc/oss_utils.py
+++ b/mobile_cv/common/misc/oss_utils.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+
+from mobile_cv.common.misc.py import dynamic_import
+
+
+def is_oss():
+    try:
+        import mobile_cv.common.misc.fb.open_source_canary as open_source_canary
+
+        assert open_source_canary
+        ret = False
+    except ImportError:
+        ret = True
+
+    return ret
+
+
+def fb_overwritable():
+    """Decorator on function that has alternative internal implementation"""
+
+    def deco(oss_func):
+        if is_oss():
+            return oss_func
+        else:
+            oss_module = oss_func.__module__
+            fb_module = oss_module + "_fb"  # xxx.py -> xxx_fb.py
+            fb_func = dynamic_import("{}.{}".format(fb_module, oss_func.__name__))
+            return fb_func
+
+    return deco


### PR DESCRIPTION
Summary: `is_oss` and `fb_overwritable` are also needed in `mobile_cv`, move them from d2go.

Differential Revision: D36655821

