### PR TITLE
support lazy object in registry

### DIFF
--- a/mobile_cv/common/misc/registry.py
+++ b/mobile_cv/common/misc/registry.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import logging
+import types
+from typing import Dict, Generic, ItemsView, KeysView, List, Optional, TypeVar, Union
 
-class Registry(object):
+from mobile_cv.common.misc.py import dynamic_import
+
+logger = logging.getLogger(__name__)
+
+
+VT = TypeVar("VT")
+CLASS_OR_FUNCTION_TYPES = (types.FunctionType, type)  # how to type annotate this?
+
+
+# NOTE: we can do `VK = TypeVar("VK")` and `Generic[VK, VT]` if the key can be non-string.
+class Registry(Generic[VT]):
     """
     The registry that provides name -> object mapping, to support third-party
       users' custom modules.
@@ -18,26 +31,46 @@ class Registry(object):
         BACKBONE_REGISTRY.register(name="MyBackbone", obj=MyBackbone)
     """
 
-    def __init__(self, name, allow_override=False):
+    def __init__(self, name: str, allow_override: bool = False) -> None:
         """
         Args:
             name (str): the name of this registry
         """
-        self._name = name
-        self._allow_override = allow_override
+        self._name: str = name
+        self._allow_override: bool = allow_override
 
-        self._obj_map = {}
+        self._obj_map: Dict[str, Union[VT, str]] = {}
 
-    def _do_register(self, name, obj):
+    def _do_register(
+        self,
+        name: str,
+        obj: Union[VT, str],
+    ) -> None:
+        """
+        The obj could be either a function/class or a "module-dot-name" string pointing
+        to the function/class. When the obj is stirng, the pointed function/calss will
+        be registered lazily.
+        """
         if name in self._obj_map and not self._allow_override:
-            raise ValueError(
-                "An object named '{}' was already registered in '{}' registry!".format(
-                    name, self._name
+            # allow replacing lazy object with actual object
+            if not (
+                isinstance(self._obj_map[name], str)
+                and isinstance(obj, CLASS_OR_FUNCTION_TYPES)
+                and self._obj_map[name] == f"{obj.__module__}.{obj.__qualname__}"
+            ):
+                raise ValueError(
+                    "An object named '{}' was already registered in '{}' registry!"
+                    " Existing object ({}) vs new object ({})".format(
+                        name, self._name, self._obj_map[name], obj
+                    )
                 )
-            )
         self._obj_map[name] = obj
 
-    def register(self, name=None, obj=None):
+    def register(
+        self,
+        name: Optional[str] = None,
+        obj: Optional[Union[VT, str]] = None,
+    ) -> Union[types.FunctionType, None]:
         """
         Register the given object under the the name or `obj.__name__` if name is None.
         Can be used as either a decorator or not. See docstring of this class for usage.
@@ -55,44 +88,63 @@ class Registry(object):
 
         # used as a function call
         if name is None:
+            assert not isinstance(
+                obj, str
+            ), f"Can't lazy-register {obj} without specifying name"
+            assert isinstance(
+                obj, CLASS_OR_FUNCTION_TYPES
+            ), f"Can't infer name for non function/class object: {obj}"
             name = obj.__name__
         self._do_register(name, obj)
 
-    def register_dict(self, mapping):
+    def register_dict(self, mapping: Dict[str, Union[VT, str]]) -> None:
         """
         Register a dict of objects
         """
         assert isinstance(mapping, dict)
         [self.register(name, obj) for name, obj in mapping.items()]
 
-    def get(self, name, is_raise=True):
+    def get(self, name: str, is_raise: bool = True) -> VT:
         """
         Raise an exception if the key is not found if `is_raise` is True,
-          return None otherwise
+            return None otherwise.
+        The lazy-registered object will be resolved.
         """
         ret = self._obj_map.get(name)
+
         if ret is None and is_raise:
             raise KeyError(
                 "No object named '{}' found in '{}' registry! Available names: {}".format(
                     name, self._name, list(self._obj_map.keys())
                 )
             )
+
+        # resolve lazy registration by dynamic importing the object, note that if the
+        # module is imported for the first time, it will re-register the actual object
+        # thus updating self._obj_map.
+        if isinstance(ret, str):
+            logger.info(f"Resolving lazy object '{ret}' in '{self._name}' registry ...")
+            ret = dynamic_import(ret)
+            assert isinstance(ret, CLASS_OR_FUNCTION_TYPES)
+
         return ret
 
-    def get_names(self):
-        return self._obj_map.keys()
+    def get_names(self) -> List[str]:
+        return list(self._obj_map.keys())
 
-    def items(self):
+    def items(self) -> ItemsView[str, Union[VT, str]]:
+        # NOTE: won't resolve lazy object
         return self._obj_map.items()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._obj_map)
 
-    def keys(self):
+    def keys(self) -> KeysView[str]:
         return self._obj_map.keys()
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return key in self._obj_map
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Union[VT, str]:
+        # NOTE: won't resolve lazy object
         return self._obj_map[key]

--- a/mobile_cv/common/tests/test_registry.py
+++ b/mobile_cv/common/tests/test_registry.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+import os
+import sys
 import unittest
+import uuid
 
+from mobile_cv.common.misc.file_utils import make_temp_directory
 from mobile_cv.common.misc.registry import Registry
 
 
 def test_func():
     return "test_func"
+
+
+TEST_LAZY_REGISTRY = Registry("test_lazy")
 
 
 class TestRegistry(unittest.TestCase):
@@ -25,3 +32,28 @@ class TestRegistry(unittest.TestCase):
         self.assertEqual(out, "test_func")
         out1 = REG_LIST.get("test_func1")()
         self.assertEqual(out1, "test_func_1")
+
+    def test_lazy_registration(self):
+        random_package_name = f"random_package_{str(uuid.uuid4().hex)[:8]}"
+        self.assertTrue(random_package_name not in sys.modules)
+
+        # we can even do lazy register before the code exists
+        TEST_LAZY_REGISTRY.register("lazy_func1", f"{random_package_name}.lazy_func1")
+
+        with make_temp_directory("test_lazy_registration") as root:
+            os.makedirs(os.path.join(root, random_package_name))
+            with open(os.path.join(root, random_package_name, "__init__.py"), "w") as f:
+                f.write(
+                    f"""
+from {__package__}.test_registry import TEST_LAZY_REGISTRY
+@TEST_LAZY_REGISTRY.register()
+def lazy_func1():
+    return "lazy_func1"
+"""
+                )
+            # make test files import-able
+            sys.path.append(root)
+
+            # resolve the lazy registered object
+            lazy_func1 = TEST_LAZY_REGISTRY.get("lazy_func1")
+            self.assertEqual(lazy_func1(), "lazy_func1")


### PR DESCRIPTION
Summary: Original `Registry` support register Function/Class. This diff supports register lazy version of Function/Class, which is represented by a string containing "module-dot-name" (eg. a class with name `MyClass` under module `d2go/a/b/c.py` will be represented as `d2go.a.b.c.MyClass`).

Reviewed By: tglik

Differential Revision: D36414579

