### PR TITLE
Replace qconfig_dict with a config object

### DIFF
--- a/mobile_cv/arch/utils/quantize_utils.py
+++ b/mobile_cv/arch/utils/quantize_utils.py
@@ -193,7 +193,7 @@ class PostQuantizationFX(object):
             qconfig_dict = {"": self.qconfig}
         self._prepared_model = torch.ao.quantization.quantize_fx.prepare_fx(
             self.model,
-            qconfig_dict=qconfig_dict,
+            qconfig_dict,
             example_inputs=example_inputs,
         )
         return self


### PR DESCRIPTION
Summary:
**Summary:** Previously, FX graph mode quantization configurations
were specified through a dictionary of qconfigs. However, this
API was not in line with other core APIs in PyTorch. This commit
replaces this dictionary with a config object that users will
create and pass to prepare and convert. This leads to better
type safety and better user experience in notebook settings
due to improved auto completion.

The new API is as follows:

```
from torch.ao.quantization import QConfigMapping
from torch.ao.quantization.quantize_fx import prepare_fx

qconfig_mapping = QConfigMapping()
    .set_global(qconfig)
    .set_object_type(torch.nn.Linear, qconfig)
    .set_module_name_regex("foo.*bar", qconfig)
    .set_module_name("mod", qconfig)

prepare_fx(model, qconfig_mapping)
```

For backwards compatibility, `prepare_fx`, `prepare_qat_fx`,
and `convert_fx` will continue to accept qconfig_dicts, which
will be converted to QuantizationConfigs internally.

Note that this commit does not modify existing tests to use the
new API; they will continue to pass in qconfig_dict as before,
which still works but triggers a deprecation warning. This will
be handled in a future commit.

**Test Plan:**
python test/test_quantization.py TestQuantizeFx
python test/test_quantization.py TestQuantizeFxOps

**Reviewers:** jerryzh168, vkuzo

**Subscribers:** jerryzh168, vkuzo

Differential Revision: D36747998

