### PR TITLE
support helper decorator for DDP test

### DIFF
--- a/mobile_cv/common/misc/py.py
+++ b/mobile_cv/common/misc/py.py
@@ -10,6 +10,8 @@ import sys
 import threading
 import traceback
 
+import cloudpickle
+
 try:
     import fcntl
 except ImportError:
@@ -139,3 +141,34 @@ def post_mortem_if_fail(pdb_=None):
         return new_func
 
     return decorator
+
+
+# Copied from detectron2/utils/serialize.py
+class PicklableWrapper(object):
+    """
+    Wrap an object to make it more picklable, note that it uses
+    heavy weight serialization libraries that are slower than pickle.
+    It's best to use it only on closures (which are usually not picklable).
+
+    This is a simplified version of
+    https://github.com/joblib/joblib/blob/master/joblib/externals/loky/cloudpickle_wrapper.py
+    """
+
+    def __init__(self, obj):
+        while isinstance(obj, PicklableWrapper):
+            # Wrapping an object twice is no-op
+            obj = obj._obj
+        self._obj = obj
+
+    def __reduce__(self):
+        s = cloudpickle.dumps(self._obj)
+        return cloudpickle.loads, (s,)
+
+    def __call__(self, *args, **kwargs):
+        return self._obj(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        # Ensure that the wrapped object can be used seamlessly as the previous object.
+        if attr not in ["_obj"]:
+            return getattr(self._obj, attr)
+        return getattr(self, attr)

--- a/mobile_cv/torch/tests/utils_pytorch/test_distributed_helper.py
+++ b/mobile_cv/torch/tests/utils_pytorch/test_distributed_helper.py
@@ -18,6 +18,12 @@ def _test_func(value):
 
 
 class TestUtilsPytorchDistributedHelper(unittest.TestCase):
+    def setUp(self):
+        self.magic_value = 42
+
+    def get_magic_value(self):
+        return 42
+
     def test_distributed_helper_launch(self):
         result = dh.launch(
             _test_func,
@@ -26,3 +32,48 @@ class TestUtilsPytorchDistributedHelper(unittest.TestCase):
             args=(3,),
         )
         self.assertEqual(result, {"a": torch.tensor([5.5]), "b": torch.tensor([6.5])})
+
+    @dh.launch_deco(num_processes=2)
+    def test_distributed_helper_launch_deco(self):
+        rank = comm.get_rank()
+        value = 3
+        data = {
+            "a": torch.tensor([2.0 + value + rank]),
+            "b": torch.tensor([3.0 + value + rank]),
+        }
+        result = comm.reduce_dict(data)
+        if rank == 0:
+            self.assertEqual(
+                result, {"a": torch.tensor([5.5]), "b": torch.tensor([6.5])}
+            )
+
+    @dh.launch_deco(num_processes=2)
+    def _test_launch_deco_with_args(self, inputs, outputs):
+        self.assertEqual(len(inputs), comm.get_world_size())
+        self.assertEqual(len(outputs), comm.get_world_size())
+        rank = comm.get_rank()
+        results = comm.all_gather(inputs[rank])
+        self.assertEqual(results, outputs)
+
+    def test_launch_deco_with_args(self):
+        inputs = outputs = [1, 2]
+        self._test_launch_deco_with_args(inputs, outputs)
+
+    @dh.launch_deco(num_processes=1)
+    def test_launch_deco_access_member_variables(self):
+        self.assertEqual(self.magic_value, 42)
+        self.assertEqual(self.get_magic_value(), 42)
+
+    # @dh.launch_deco(num_processes=2, launch_method="elastic")  # elastic is slow
+    # def test_elastic_launch(self):
+    #     rank = comm.get_rank()
+    #     ranks = comm.all_gather(rank)
+    #     self.assertEqual(ranks, [0, 1])
+    #     world_size = comm.get_world_size()
+    #     self.assertEqual(world_size, 2)
+    #     # test local process group
+    #     local_rank = comm.get_local_rank()
+    #     local_ranks = comm.all_gather(local_rank)
+    #     self.assertEqual(local_ranks, [0, 1])
+    #     local_world_size = comm.get_local_size()
+    #     self.assertEqual(local_world_size, 2)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "iopath",
         "diskcache",
         "termcolor",
+        "cloudpickle",
     ],
     extras_require={},
     packages=find_packages(),


### PR DESCRIPTION
Summary:
This is a upgraded version of `enable_ddp_env`,

https://www.internalfb.com/code/fbsource/[7ef937973ce234c810faf7f76492331618459d1b]/fbcode/mobile-vision/d2go/d2go/utils/testing/helper.py?lines=44

It allows taking `num_processes` as argument and actually launch it using mobile_cv's `dh.launch`. We can merge `enable_ddp_env` into this in the future.

Differential Revision: D36796904

