### PR TITLE
making bootstrap more robust

### DIFF
--- a/mobile_cv/common/tests/test_misc.py
+++ b/mobile_cv/common/tests/test_misc.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 
 from mobile_cv.common.misc.file_utils import make_temp_directory
-from mobile_cv.common.misc.py import dynamic_import, import_file
+from mobile_cv.common.misc.py import dynamic_import, import_file, MoreMagicMock
 
 
 class TestMisc(unittest.TestCase):
@@ -42,3 +42,26 @@ class TestMisc(unittest.TestCase):
             from test_package.lib.a import bar
 
             self.assertEqual(bar, 42)
+
+
+class TestMoreMagicMock(unittest.TestCase):
+    def test_magic_methods(self):
+        torch = MoreMagicMock()  # this fails if using mock.MagicMock()
+        result = torch.__version__ > "1.2.3"
+        self.assertIsInstance(result, MoreMagicMock)
+
+    def test_inheritance(self):
+        nn = MoreMagicMock()
+        self.assertIsInstance(nn.Module, MoreMagicMock)
+
+        class MockedClass(nn.Module):
+            pass
+
+        class NormalClass(object):
+            pass
+
+        self.assertIsInstance(MockedClass, MoreMagicMock)
+        self.assertIsInstance(MockedClass.whatever_func, MoreMagicMock)
+        x = MockedClass
+        self.assertEqual(x.mocked_obj_info["__name__"], "MockedClass")
+        self.assertEqual(x.mocked_obj_info["__module__"], NormalClass.__module__)


### PR DESCRIPTION
Summary:
- add `MoreMagicMock`, which handles inheritance and comparison.
- also support lazy registering mocked objects (has to be `MoreMagicMock`).
- don't need to skip `skip files that doesn't contain ".register()" call` since we can handle most files pretty well now.
- also mock the open
- delay the import for `from detectron2.utils.testing import assert_instances_allclose`; for some reason python is doing magic things if you import anything starting with `assert`, so the mocked import doesn't work.
- makes log function nicer.

Differential Revision: D36798327

