### PR TITLE
make launch return results from all ranks

### DIFF
--- a/mobile_cv/torch/tests/utils_pytorch/test_central_process_data_loader.py
+++ b/mobile_cv/torch/tests/utils_pytorch/test_central_process_data_loader.py
@@ -68,32 +68,35 @@ def _test_func_max_qsize(num_items, max_qsize):
 
 class TestUtilsPytorchCentralProcessDataLoader(unittest.TestCase):
     def test_central_process_data_loader_single_process(self):
-        result = dh.launch(
+        results = dh.launch(
             _test_func,
             num_processes_per_machine=1,
             backend="GLOO",
             args=(10,),
         )
+        result = results[0]
         self.assertEqual(result, list(range(10)))
 
     def test_central_process_data_loader_single_process_single_enqueue(self):
         # the enqueue func will run in main process as well
         single_process = True
-        result = dh.launch(
+        results = dh.launch(
             _test_func,
             num_processes_per_machine=1,
             backend="GLOO",
             args=(10, single_process),
         )
+        result = results[0]
         self.assertEqual(result, list(range(10)))
 
     def test_central_process_data_loader_multi_process(self):
-        result = dh.launch(
+        results = dh.launch(
             _test_func,
             num_processes_per_machine=2,
             backend="GLOO",
             args=(10,),
         )
+        result = results[0]
         self.assertEqual(result, sorted(result))
         self.assertLess(len(result), 10)
         self.assertTrue(all(x in range(10) for x in result))
@@ -101,12 +104,13 @@ class TestUtilsPytorchCentralProcessDataLoader(unittest.TestCase):
     # FIXME: this test fails on OSS
     @unittest.skipIf(is_oss(), "this test fails on OSS")
     def test_central_process_data_loader_multi_process_unbalanced(self):
-        result = dh.launch(
+        results = dh.launch(
             _test_func_unbalanced,
             num_processes_per_machine=2,
             backend="GLOO",
             args=(10,),
         )
+        result = results[0]
         self.assertEqual(result, sorted(result))
         self.assertEqual(len(result), 9)
         self.assertTrue(all(x in range(10) for x in result))
@@ -114,12 +118,13 @@ class TestUtilsPytorchCentralProcessDataLoader(unittest.TestCase):
     def test_central_process_data_loader_maxqsize(self):
         # test the queue size is 1
         max_qsize = 1
-        result = dh.launch(
+        results = dh.launch(
             _test_func_max_qsize,
             num_processes_per_machine=1,
             backend="GLOO",
             args=(10, max_qsize),
         )
+        result = results[0]
         self.assertEqual(result, list(range(10)))
 
 

--- a/mobile_cv/torch/tests/utils_pytorch/test_distributed_helper.py
+++ b/mobile_cv/torch/tests/utils_pytorch/test_distributed_helper.py
@@ -28,13 +28,18 @@ class TestUtilsPytorchDistributedHelper(unittest.TestCase):
         return 42
 
     def test_distributed_helper_launch(self):
-        result = dh.launch(
+        results = dh.launch(
             _test_func,
             num_processes_per_machine=2,
             backend="GLOO",
             args=(3,),
         )
-        self.assertEqual(result, {"a": torch.tensor([5.5]), "b": torch.tensor([6.5])})
+        self.assertEqual(
+            results[0], {"a": torch.tensor([5.5]), "b": torch.tensor([6.5])}
+        )
+        self.assertEqual(
+            results[1], {"a": torch.tensor([6.0]), "b": torch.tensor([7.0])}
+        )
 
     @dh.launch_deco(num_processes=2)
     def test_distributed_helper_launch_deco(self):
@@ -48,6 +53,10 @@ class TestUtilsPytorchDistributedHelper(unittest.TestCase):
         if rank == 0:
             self.assertEqual(
                 result, {"a": torch.tensor([5.5]), "b": torch.tensor([6.5])}
+            )
+        else:
+            self.assertEqual(
+                result, {"a": torch.tensor([6.0]), "b": torch.tensor([7.0])}
             )
 
     @dh.launch_deco(num_processes=2)


### PR DESCRIPTION
Summary:
Similar to `elastic_launch`, make `launch` return results for all ranks, this is beneficial for cases where each rank having different return value`.

There'll be some test failing for V1, it'll help finding related callsites.

Reviewed By: tglik

Differential Revision: D37016935

