### PR TITLE
Use traceable model and flattened inputs if available

### DIFF
--- a/mobile_cv/model_zoo/tools/utils.py
+++ b/mobile_cv/model_zoo/tools/utils.py
@@ -4,6 +4,8 @@ import json
 import os
 import shutil
 
+import torch
+
 
 def copy_file(src, dst, skip_exists=True):
     if os.path.exists(src):
@@ -17,3 +19,14 @@ def copy_file(src, dst, skip_exists=True):
 def save_json(file, data):
     with open(file, "w") as outfile:
         json.dump(data, outfile, indent=4, sort_keys=True)
+
+
+def get_model_attributes(model: torch.nn.Module):
+    model_attrs = None
+    if hasattr(model, "attrs"):
+        model_attrs = model.attrs
+        if model_attrs is not None:
+            assert isinstance(
+                model_attrs, dict
+            ), f"Invalid model attributes type: {model_attrs}"
+    return model_attrs


### PR DESCRIPTION
Summary:
If task has `get_traceable_model` and `get_flattened_inputs`, use those for torchscript export, otherwise use the default behaviour.

This is needed for models which have tuple / dict as input.

Differential Revision: D36999453

