### PR TITLE
support bootstrap package with existing registerables

### DIFF
--- a/mobile_cv/common/misc/registry.py
+++ b/mobile_cv/common/misc/registry.py
@@ -102,7 +102,7 @@ class Registry(Generic[VT]):
         self,
         name: Optional[str],
         obj: Union[VT, LazyRegisterable],
-    ):
+    ) -> None:
         """
         Before calling `_do_register`, resolve the `name` from `obj` in case the `name`
         is not explicity set.


### PR DESCRIPTION
Summary: We may import d2go first, which populates some builtin meta archs in registry, then do the bootstrap.

Differential Revision: D37427101

