### PR TITLE
Fuse FrozenBatchNorm during model export

### DIFF
--- a/mobile_cv/arch/utils/fuse_utils.py
+++ b/mobile_cv/arch/utils/fuse_utils.py
@@ -10,6 +10,7 @@ import mobile_cv.arch.layers
 import mobile_cv.common.misc.registry as registry
 import torch
 import torch.nn as nn
+from detectron2.layers.batch_norm import FrozenBatchNorm2d
 from mobile_cv.arch.fbnet_v2.spade import _get_fuser_name_convbnrelu_with_tuple_left
 from mobile_cv.arch.layers.batch_norm import (
     NaiveSyncBatchNorm,
@@ -153,6 +154,8 @@ def fuse_more_modules(
         (torch.nn.Conv1d, nn.SyncBatchNorm, torch.nn.ReLU): fuse_conv_bn_relu,
         (torch.nn.Conv2d, NaiveSyncBatchNorm): fuse_conv_bn,
         (torch.nn.Conv2d, NaiveSyncBatchNorm, torch.nn.ReLU): fuse_conv_bn_relu,
+        (torch.nn.Conv2d, FrozenBatchNorm2d): fuse_conv_bn,
+        (torch.nn.Conv2d, FrozenBatchNorm2d, torch.nn.ReLU): fuse_conv_bn_relu,
         (torch.nn.Conv2d, nn.SyncBatchNorm): fuse_conv_bn,
         (torch.nn.Conv2d, nn.SyncBatchNorm, torch.nn.ReLU): fuse_conv_bn_relu,
         (torch.nn.Conv3d, NaiveSyncBatchNorm3d): fuse_conv_bn,

--- a/mobile_cv/torch/cpp/caffe2_ops/meta_conv.cu
+++ b/mobile_cv/torch/cpp/caffe2_ops/meta_conv.cu
@@ -1,6 +1,6 @@
 #include "meta_conv.h"
 
-#include "caffe2/core/context_gpu.h"
+#include "caffe2/caffe2/core/context_gpu.h"
 
 namespace caffe2 {
 

--- a/mobile_cv/torch/cpp/caffe2_ops/meta_conv.h
+++ b/mobile_cv/torch/cpp/caffe2_ops/meta_conv.h
@@ -1,9 +1,9 @@
 #ifndef META_CONV_OP_H_
 #define META_CONV_OP_H_
 
-#include "caffe2/core/context.h"
-#include "caffe2/core/export_caffe2_op_to_c10.h"
-#include "caffe2/core/operator.h"
+#include "caffe2/caffe2/core/context.h"
+#include "caffe2/caffe2/core/export_caffe2_op_to_c10.h"
+#include "caffe2/caffe2/core/operator.h"
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(MetaConv)
 

--- a/mobile_cv/torch/cpp/caffe2_ops/meta_output.cu
+++ b/mobile_cv/torch/cpp/caffe2_ops/meta_output.cu
@@ -1,6 +1,6 @@
 #include "meta_output.h"
 
-#include "caffe2/core/context_gpu.h"
+#include "caffe2/caffe2/core/context_gpu.h"
 
 namespace caffe2 {
 

--- a/mobile_cv/torch/cpp/caffe2_ops/meta_output.h
+++ b/mobile_cv/torch/cpp/caffe2_ops/meta_output.h
@@ -1,9 +1,9 @@
 #ifndef META_OUTPUT_OP_H_
 #define META_OUTPUT_OP_H_
 
-#include "caffe2/core/context.h"
-#include "caffe2/core/export_caffe2_op_to_c10.h"
-#include "caffe2/core/operator.h"
+#include "caffe2/caffe2/core/context.h"
+#include "caffe2/caffe2/core/export_caffe2_op_to_c10.h"
+#include "caffe2/caffe2/core/operator.h"
 
 C10_DECLARE_EXPORT_CAFFE2_OP_TO_C10(MetaOutput)
 


### PR DESCRIPTION
Summary: Add ``FrozenBatchNorm2d`` to fuse function to allow export a (pretrained) model with frozen batchnorm. Note that in face tracking, the head is not built with fbnet builder thus we have to pass ``FrozenBatchNorm`` in ``fuse_custom_config_dict`` argument to ``fuse_modules``

Differential Revision: D38144204

