### PR TITLE
Use TorchVision's Model Registration API

### DIFF
--- a/mobile_cv/model_zoo/models/model_torchvision.py
+++ b/mobile_cv/model_zoo/models/model_torchvision.py
@@ -12,63 +12,19 @@ from mobile_cv.model_zoo.models.hub_utils import pretrained_download
 from . import model_zoo_factory  # noqa
 
 
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnet18`.
-    "resnet18",
-    pretrained_download(torchvision.models.resnet18),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnet34`.
-    "resnet34",
-    pretrained_download(torchvision.models.resnet34),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnet50`.
-    "resnet50",
-    pretrained_download(torchvision.models.resnet50),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnet101`.
-    "resnet101",
-    pretrained_download(torchvision.models.resnet101),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnet152`.
-    "resnet152",
-    pretrained_download(torchvision.models.resnet152),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnext50_32x4d`.
-    "resnext50_32x4d",
-    pretrained_download(torchvision.models.resnext50_32x4d),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `resnext101_32x8d`.
-    "resnext101_32x8d",
-    pretrained_download(torchvision.models.resnext101_32x8d),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `swin_s`.
-    "swin_s",
-    pretrained_download(torchvision.models.swin_s),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `efficientnet_b0`.
-    "efficientnet_b0",
-    pretrained_download(torchvision.models.efficientnet_b0),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `efficientnet_v2_s`.
-    "efficientnet_v2_s",
-    pretrained_download(torchvision.models.efficientnet_v2_s),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `mobilenet_v3_large`.
-    "mobilenet_v3_large",
-    pretrained_download(torchvision.models.mobilenet_v3_large),
-)
-model_zoo_factory.MODEL_ZOO_FACTORY.register(
-    # pyre-fixme[16]: Module `models` has no attribute `convnext_small`.
-    "convnext_small",
-    pretrained_download(torchvision.models.convnext_small),
-)
+if hasattr(torchvision.models, "list_models"):
+    # TorchVision >= v0.14
+    tv_models = torchvision.models.list_models(torchvision.models)
+else:
+    tv_models = [
+        v.__name__
+        for k, v in torchvision.models.__dict__.items()
+        if callable(v) and k[0].islower() and k[0] != "_" and k != "get_weight"
+    ]
+
+for model_name in tv_models:
+    if model_name not in model_zoo_factory.MODEL_ZOO_FACTORY:
+        model_zoo_factory.MODEL_ZOO_FACTORY.register(
+            model_name,
+            pretrained_download(torchvision.models.__dict__[model_name]),
+        )


### PR DESCRIPTION
Summary: TorchVision has introduced a [Model Registration API](https://pytorch.org/blog/easily-list-and-initialize-models-with-new-apis-in-torchvision/) which allows to easily list all existing models. The API is being adopted by multiple external frameworks like MMLabs, Lightning and fastai. We believe it will beneficial to add it on MobileCV so that the users of MobileVision can get access directly to the available backbones of TorchVision.

Differential Revision: D39374209

