### PR TITLE
OS Environ exception -> warning

### DIFF
--- a/mobile_cv/torch/utils_pytorch/distributed_helper.py
+++ b/mobile_cv/torch/utils_pytorch/distributed_helper.py
@@ -108,9 +108,9 @@ class DistributedParams(object):
     def set_environ(cls, params: "DistributedParams") -> None:
         def _set_env_key(key: str, value: str):
             if key in os.environ and (curr_value := os.environ[key]) != value:
-                raise RuntimeError(
+                logger.warning(
                     f"Key {key} already set in OS environ. "
-                    f"Current value {curr_value}, attempt to overwrite with {value}."
+                    f"Current value {curr_value}, overwriting with {value}."
                 )
             os.environ[key] = value
 


### PR DESCRIPTION
Summary: Some workflows set this differently because of how they do data loading, so instead of throwing, let's just warn when this happens.

Differential Revision: D39889563

