### PR TITLE
Add shared workers context API

### DIFF
--- a/mobile_cv/torch/utils_pytorch/comm.py
+++ b/mobile_cv/torch/utils_pytorch/comm.py
@@ -17,6 +17,36 @@ This variable is set when processes are spawned by `launch()` in "engine/launch.
 _LOCAL_PROCESS_GROUP: Optional[dist.ProcessGroup] = None
 
 
+class BaseSharedContext(object):
+    """
+    Base class for shared context that can be initialied before launching the workers
+    passed to all workers.
+    """
+
+    pass
+
+
+# Distributed shared context for all workers
+_GLOBAL_SHARED_CONTEXT: Optional[BaseSharedContext] = None
+
+
+def set_shared_context(value: BaseSharedContext) -> None:
+    """Set distributed shared context for all workers"""
+    assert isinstance(
+        value, BaseSharedContext
+    ), "Shared context must be a BaseSharedContext"
+    global _GLOBAL_SHARED_CONTEXT
+    _GLOBAL_SHARED_CONTEXT = value
+
+
+def get_shared_context() -> BaseSharedContext:
+    """Get distributed shared context for all workers"""
+    assert (
+        _GLOBAL_SHARED_CONTEXT is not None
+    ), "Shared context is not set. Missing shared context initilization"
+    return _GLOBAL_SHARED_CONTEXT
+
+
 def get_world_size() -> int:
     if not dist.is_available():
         return 1


### PR DESCRIPTION
Summary:
D2 (https://github.com/facebookresearch/mobile-vision/commit/7914225ba03bbe8f17eec22cb30a1fc1f56e91c9)Go doesn't have per node initialization api, but only per worker initialization that happens per subprocess.
Some projects (like IOBT) need to way to do shared initialization before spawning all the workers in subprocess and pass this initialized shared context to the workers.
This diff adds API to create a shared context object before launching workers and then use this shared context by the runners inside the workers after launch.

Reviewed By: wat3rBro

Differential Revision: D40001329

