### PR TITLE
fuse_utils footprint update to match fuse_known_modules

### DIFF
--- a/mobile_cv/arch/utils/fuse_utils.py
+++ b/mobile_cv/arch/utils/fuse_utils.py
@@ -128,7 +128,7 @@ def swap_modules(
 
 # TODO: Is this the same as fuse_known_modules? should we just refactor this using `additioanl_fuser_method_mapping`?
 def fuse_more_modules(
-    mod_list: typing.List[nn.Module], additional_fuser_method_mapping=None, is_qat=False
+    mod_list: typing.List[nn.Module], is_qat=False, additional_fuser_method_mapping=None
 ):
     r"""Returns a list of modules that fuses the operations specified
      in the input module list.


### PR DESCRIPTION
Summary: fuse_more_module's footprint is not in the right order. It was previously not an issue due to another bug so fuse_more_module was not actually called: D40722395.

Differential Revision: D40785714

