### PR TITLE
Switch the order of condition to simplify inference mode

### DIFF
--- a/mobile_cv/arch/layers/batch_norm.py
+++ b/mobile_cv/arch/layers/batch_norm.py
@@ -107,7 +107,7 @@ class NaiveSyncBatchNorm(nn.BatchNorm2d):
         self._stats_mode = stats_mode
 
     def forward(self, input):
-        if get_world_size() == 1 or not self.training:
+        if not self.training or get_world_size() == 1:
             return super().forward(input)
 
         B, C = input.shape[0], input.shape[1]


### PR DESCRIPTION
Summary: The  check get_world_size() == 1 is not related in inference mode. We switch their order so as to simplify the model tracing process.

Differential Revision: D40821091

