### PR TITLE
Support exporting quantized Argos model to boltnn

### DIFF
--- a/mobile_cv/model_zoo/tools/model_exporter.py
+++ b/mobile_cv/model_zoo/tools/model_exporter.py
@@ -381,6 +381,7 @@ def export_to_executorch_dynamic(
     inputs,
     output_base_dir,
     *,
+    data_iter,
     export_format=None,
     **kwargs,
 ):
@@ -389,6 +390,10 @@ def export_to_executorch_dynamic(
     for export, `model_name` starts with `executorch_` prefix.
     """
     assert hasattr(task, "get_model_by_name")
+
+    if export_format in ["executorch_int8", "executorch_boltnn"]:
+        ptq_model, model_attrs = get_ptq_model(args, task, model, inputs, data_iter)
+        ptq_model(*inputs)
 
     exec_prog = task.get_model_by_name(export_format, model)
     flatbuffer = exec_prog.buffer


### PR DESCRIPTION
Summary:
Added two apis for exporting `executorch_int8` and `executorch_boltnn` formats of Argos model. Model will be quantized first, then converted to executorch program, and delegated to boltnn backend.

For model quantization, the new quantization flow with `_convert_to_reference_decomposed_fx` is required for executorch stack.

Reviewed By: Yinan-Zhao

Differential Revision: D42106159

