### PR TITLE
Remove usage of weights.from_str

### DIFF
--- a/mobile_cv/model_zoo/models/model_torchvision.py
+++ b/mobile_cv/model_zoo/models/model_torchvision.py
@@ -36,9 +36,10 @@ def _get_builder(model_name):
         model_fn = _get_model_builder(model_name)
         if kwargs.pop("pretrained", False):
             if _tv_version >= parse_version("0.14.0a0"):
-                kwargs["weights"] = torchvision.models.get_model_weights(
-                    model_fn
-                ).from_str("IMAGENET1K_V1")
+                kwargs["weights"] = torchvision.models.get_model_weights(model_fn)[
+                    "IMAGENET1K_V1"
+                ]
+
             elif _tv_version >= parse_version("0.13"):
                 kwargs["weights"] = "IMAGENET1K_V1"
             else:


### PR DESCRIPTION
Summary:
This was a private API that we removed in D43116103. Using normal indexing instead `[]`.

This diff should avoid having to land the revert stack at D43157078 - sorry for the inconvenience

Differential Revision: D43160580

