### PR TITLE
add correctness test for ai infra checkpointer with FSDP local mode in d2go runner

### DIFF
--- a/mobile_cv/torch/utils_pytorch/distributed_helper.py
+++ b/mobile_cv/torch/utils_pytorch/distributed_helper.py
@@ -418,6 +418,7 @@ def launch_deco(
     launch_method: str = "multiprocessing",
     timeout: timedelta = DEFAULT_UNITTEST_TIMEOUT,
     shared_context: Optional[comm.BaseSharedContext] = None,
+    launcher: Callable = launch,
 ) -> Callable[[Callable[..., _RT]], Callable[..., Dict[int, _RT]]]:
     """
     A helper decorator to run the instance method via `launch`. This is convenient
@@ -429,7 +430,7 @@ def launch_deco(
         # very useful for unittest.
         @functools.wraps(func)
         def _launch_func(self, *args, **kwargs) -> Dict[int, _RT]:
-            results = launch(
+            results = launcher(
                 # make func pickable for the sake of multiprocessing.spawn
                 PicklableWrapper(func),
                 num_processes_per_machine=num_processes,


### PR DESCRIPTION
Summary:
This diff adds a correctness test for ai infra checkpointer + FSDP local mode within a d2go runner. It verifies that ai infra checkpointer saves the exact same model as the old checkpointer, and that we can convert between ai infra checkpoints (local) and fsdp checkpoints (local + global) seamlessly.

Note: adapted from mattcyu1's script D43492498.

## Testing

Testing is done by saving with both ai infra and fsdp checkponter and compare the state dict produced. Here are the steps:

1. Build the model. Save a local ckpt using the FSDP checkpointer and another local ckpt using the AIInfra checkpointer
2. Reset the model. Load local ckpt using the FSDP checkpointer and convert it to global ckpt
3. Reset the model. Load local ckpt using the AIInfra checkpointer and re-save it as global ckpt using the FSDP checkpointer
4. Compare the two global state dicts

## Others

1. Add a launch decorator for d2go.distributed worker using the one in `fbcode/mobile-vision/mobile_cv/mobile_cv/torch/utils_pytorch/distributed_helper.py`

2. Modify how EMA resets state when load_state_dict is called. This is needed because ai infra checkpointer loads state dict in place before ema.load_state_dict() is called. Thus, when ema tries to load itself, calling self.state.clear() will delete the input state_dict, causing ema to reset to an empty dict

Reviewed By: xunnanxu

Differential Revision: D43423572

