### PR TITLE
Replace hasattr with getattr in mobile-vision/mobile_cv/mobile_cv/arch/utils/quantize_utils.py

### DIFF
--- a/mobile_cv/arch/utils/quantize_utils.py
+++ b/mobile_cv/arch/utils/quantize_utils.py
@@ -359,7 +359,7 @@ class QuantizableModule(nn.Module):
 
 class QuantWrapper(QuantizableModule):
     def __init__(self, module, **kwargs):
-        qconfig = module.qconfig if hasattr(module, "qconfig") else None
+        qconfig = getattr(module, "qconfig", None)
         super().__init__(eager_mode=True, qconfig=qconfig, **kwargs)
         self.module = module
 


### PR DESCRIPTION
Summary:
The pattern
```
X.Y if hasattr(X, "Y") else Z
```
can be replaced with
```
getattr(X, "Y", Z)
```

The [getattr](https://www.w3schools.com/python/ref_func_getattr.asp) function gives more succinct code than the [hasattr](https://www.w3schools.com/python/ref_func_hasattr.asp) function. Please use it when appropriate.

**This diff is very low risk. Green tests indicate that you can safely Accept & Ship.**

Differential Revision: D44886683

