### PR TITLE
add assertion for dist_url

### DIFF
--- a/mobile_cv/torch/utils_pytorch/distributed_helper.py
+++ b/mobile_cv/torch/utils_pytorch/distributed_helper.py
@@ -252,6 +252,7 @@ def launch(
         kwargs = {}
 
     if dist_url is None:
+        assert num_machines == 1, "Must provide dist_url for multi-node"
         uid = uuid.uuid4().hex
         dist_url = f"file:///tmp/mcvdh_dist_file_{uid}_{time.time()}"
 


### PR DESCRIPTION
Summary: All workers must use the same dist_url / init_method, currently we call `dist_url = f"file:///tmp/mcvdh_dist_file_{uid}_{time.time()}"` to created a shared `dist_url`, but this only works for single machine, add an assertion.

Reviewed By: acisseJZhong

Differential Revision: D46339835

