### PR TITLE
get rid of renaming pattern for fbnet_v2

### DIFF
--- a/mobile_cv/arch/fbnet_v2/__init__.py
+++ b/mobile_cv/arch/fbnet_v2/__init__.py
@@ -18,6 +18,8 @@ from mobile_cv.arch.fbnet_v2 import (  # noqa
     gb_block,
     irf_3d_block,
     irf_spade,
+    mobileone_block,
     norms,
     spade,
 )
+# @fb-only: from mobile_cv.arch.fbnet_v2 import fb  # isort:skip  # noqa 

--- a/mobile_cv/arch/fbnet_v2/fbnet_hr_modeldef.py
+++ b/mobile_cv/arch/fbnet_v2/fbnet_hr_modeldef.py
@@ -3,7 +3,7 @@
 
 """
 This file is for backward compatiblity.
-Use mobile_cv.arch.builder.fbnet_hr_modeldef instead.
+Use mobile_cv.arch.builder.fb.fbnet_hr_modeldef instead.
 """
 
-from mobile_cv.arch.builder.fbnet_hr_modeldef import *  # noqa
+# @fb-only: from mobile_cv.arch.builder.fb.fbnet_hr_modeldef import *  # noqa  

--- a/mobile_cv/arch/tests/test_fbnet_v2_res_block.py
+++ b/mobile_cv/arch/tests/test_fbnet_v2_res_block.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 # import mobile_cv.lut.lib.pt.flops_utils as flops_utils
 
 # from mobile_cv.arch.fbnet_v2.fbnet_builder import FBNetBuilder
-# from mobile_cv.arch.fbnet_v2.fbnet_hr import FBNetHRBuilder
+# from mobile_cv.arch.fbnet_v2.fb.fbnet_hr import FBNetHRBuilder
 
 
 def _has_module(model, module_type):

--- a/mobile_cv/arch/utils/fbnet_utils.py
+++ b/mobile_cv/arch/utils/fbnet_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 from common.utils_pytorch.model_utils import find_module_key
-from mobile_cv.arch.fbnet.fbnet_building_blocks import ConvBNRelu, QuantConvBNRelu
+from mobile_cv.arch.fb.fbnet.fbnet_building_blocks import ConvBNRelu, QuantConvBNRelu
 from mobile_cv.arch.fbnet_v2.basic_blocks import ConvBNRelu as ConvBNReluBasic
 from mobile_cv.arch.layers import Conv2d
 from mobile_cv.common.misc.oss_utils import fb_overwritable

--- a/mobile_cv/model_zoo/models/fbnet_hr.py
+++ b/mobile_cv/model_zoo/models/fbnet_hr.py
@@ -20,8 +20,8 @@ from typing import Dict, Tuple
 
 import mobile_cv.arch.fbnet_v2.fbnet_hr_modeldef as modeldef
 import torch.nn as nn
+from mobile_cv.arch.fbnet_v2.fb.fbnet_hr import FBNetHRBuilder
 from mobile_cv.arch.fbnet_v2.fbnet_builder import FBNetBuilder
-from mobile_cv.arch.fbnet_v2.fbnet_hr import FBNetHRBuilder
 
 
 def _create_builder(arch_name: str) -> Tuple[FBNetHRBuilder, Dict]:


### PR DESCRIPTION
Summary:
```
hg mv mobile-vision/mobile_cv/mobile_cv/arch/fbnet_v2/__init__fb.py mobile-vision/mobile_cv/mobile_cv/arch/fbnet_v2/fb/__init__.py
```
Then add `.fb` for imports

Reviewed By: jiaxuzhu92

Differential Revision: D46676613

