### PR TITLE
Remove one-time inference call before exporting int8 models

### DIFF
--- a/mobile_cv/model_zoo/tools/model_exporter.py
+++ b/mobile_cv/model_zoo/tools/model_exporter.py
@@ -337,7 +337,6 @@ def export_to_torchscript_int8(
     ptq_model, model_attrs = get_ptq_model(args, task, model, inputs, data_iter)
 
     logger.info(ptq_model)
-    ptq_model(*inputs)
 
     # get model_extra_files from ptq_model if it exists
     model_extra_files = _get_model_extra_files(ptq_model)


### PR DESCRIPTION
Summary: If a model maintains its own states, doing a one-time inference before export could modify the states and cause an un-intended modification of the model. Given the code doesn't make use of the model output, I'm deleting it from the script.

Reviewed By: jiaxuzhu92

Differential Revision: D47353485

