### PR TITLE
Del `(object)` from 10 inc mobile-vision/mobile_cv/mobile_cv/common/misc/cache_counter.py

### DIFF
--- a/mobile_cv/common/misc/cache_counter.py
+++ b/mobile_cv/common/misc/cache_counter.py
@@ -62,7 +62,7 @@ class DownloadStat(Enum):
         return ret
 
 
-class CacheCounter(object):
+class CacheCounter:
     def __init__(
         self,
         name,

--- a/mobile_cv/common/misc/iter_utils.py
+++ b/mobile_cv/common/misc/iter_utils.py
@@ -7,7 +7,7 @@ from functools import wraps
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 
-class ValueKeepingGenerator(object):
+class ValueKeepingGenerator:
     def __init__(self, g):
         self.gen = g
         self.value = None
@@ -233,7 +233,7 @@ def create_pair(lhs, rhs):
 
 
 @dataclass
-class Pair(object):
+class Pair:
     lhs: Any
     rhs: Any
 

--- a/mobile_cv/common/misc/local_cache.py
+++ b/mobile_cv/common/misc/local_cache.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 import diskcache
 
 
-class Timer(object):
+class Timer:
     def __init__(self):
         self.reset()
 
@@ -42,7 +42,7 @@ class Timer(object):
         self.diff = 0.0
 
 
-class TimerDict(object):
+class TimerDict:
     def __init__(self):
         self.timers = {}
 
@@ -67,7 +67,7 @@ class TimerDict(object):
             print(f"{name}: {item.average_time} ({item.total_time}, {item.calls})")
 
 
-class LocalCache(object):
+class LocalCache:
     @classmethod
     def Create(cls, prefix, num_shards, use_timer=False):
         tmp_dir = tempfile.gettempdir()

--- a/mobile_cv/common/misc/py.py
+++ b/mobile_cv/common/misc/py.py
@@ -145,7 +145,7 @@ def post_mortem_if_fail(pdb_=None):
 
 
 # Copied from detectron2/utils/serialize.py
-class PicklableWrapper(object):
+class PicklableWrapper:
     """
     Wrap an object to make it more picklable, note that it uses
     heavy weight serialization libraries that are slower than pickle.

--- a/mobile_cv/common/misc/test_utils.py
+++ b/mobile_cv/common/misc/test_utils.py
@@ -14,7 +14,7 @@ import pkg_resources
 from mobile_cv.common.misc.oss_utils import fb_overwritable
 
 
-class SubPackageInitFileTestMixin(object):
+class SubPackageInitFileTestMixin:
     """
     A helper for creating test to check every subpackage has an __init__.py file.
 

--- a/mobile_cv/common/tests/test_iter_utils.py
+++ b/mobile_cv/common/tests/test_iter_utils.py
@@ -203,11 +203,11 @@ class TestIterUtils(unittest.TestCase):
         to the original structure"""
 
         @dataclass
-        class Type1(object):
+        class Type1:
             name: str
 
         @dataclass
-        class Type2(object):
+        class Type2:
             name: str
 
         adict = {
@@ -262,21 +262,21 @@ class TestIterUtils(unittest.TestCase):
         to the original structure"""
 
         @dataclass
-        class Type1(object):
+        class Type1:
             name: str
 
             def process(self, _):
                 return self.name + "_t1"
 
         @dataclass
-        class Type2(object):
+        class Type2:
             name: str
 
             def process(self, _):
                 return self.name + "_t2"
 
         @dataclass
-        class TypeChoice(object):
+        class TypeChoice:
             name: str
             data: List[Any]
 


### PR DESCRIPTION
Summary: Python3 makes the use of `(object)` in class inheritance unnecessary. Let's modernize our code by eliminating this.

Reviewed By: meyering

Differential Revision: D48957971


