### PR TITLE
Fix error for model with trace_type == "script"

### DIFF
--- a/mobile_cv/model_zoo/tools/model_exporter.py
+++ b/mobile_cv/model_zoo/tools/model_exporter.py
@@ -281,7 +281,7 @@ def trace_and_save_torchscript(
         if "bundled_inputs" in model_name and not save_bundle_input:
             continue
         script_model = get_script_model_with_attrs(
-            model if trace_type == "trace" else copy.deepcopy(model),
+            model,
             trace_type,
             model_inputs=inputs,
             model_attrs=model_attrs,


### PR DESCRIPTION
Summary:
Recently, we attempted to export the IOBT model. According to the method described in the test plan of D53447647, we were able to generate the corresponding BoltNN versions of the Encoder and LSTM ptl files. Each of them can be run standalone. However, when we combined these two models and tested them together, we encountered an error (P1157420937).

After our experiments, it appears that this diff can help to resolved the issue.

Differential Revision: D53483747


