### PR TITLE
clean up mobile-vision/mobile_cv/mobile_cv/model_zoo/datasets

### DIFF
--- a/mobile_cv/model_zoo/datasets/__init__.py
+++ b/mobile_cv/model_zoo/datasets/__init__.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
+from mobile_cv.common.misc.oss_utils import fb_overwritable
+
+
 # to register datasets
-from . import dataset_simple  # noqa
+@fb_overwritable()
+def register_datasets():
+    from mobile_cv.model_zoo.datasets import dataset_simple  # noqa
+
+
+register_datasets()


### PR DESCRIPTION
Summary:
This stack of diff cleans up the `mobile_cv.model_zoo` and makes it working with autodeps nicely. In general, it needs the following change:

1. relative import is replaced with absolute import
2. mapping source file is no-no for autodeps, this is introduced to hide fb code for OSS. replace it with `fb_overwritable()` (https://www.internalfb.com/intern/wiki/Mobile_Vision/Detectron2Go/Development/Work_in_open-sourced_codebase/).
3. Still keep the original split with and without classyvision dependency. But this time simply let the autodeps to figure out extra classyvision dependency.

Differential Revision: D59237876
