### PR TITLE
Convert directory fbcode/mobile-vision to use the Ruff Formatter

### DIFF
--- a/mobile_cv/arch/builder/fbnet_fpn.py
+++ b/mobile_cv/arch/builder/fbnet_fpn.py
@@ -137,8 +137,7 @@ class FBNetFPNBuilder:
         self.num_stages = self.num_resolutions * self.num_stages_per_resolution - 1
         assert (
             # num_stages == num_resolutions * num_stages_per_resolution - 1
-            len(arch_def["stages"])
-            >= self.num_stages
+            len(arch_def["stages"]) >= self.num_stages
         ), (
             f"FBNet FPN requires 4 stages per spatial resolution and in "
             f"total {self.num_resolutions - 1} stages for cross-resolution connections"

--- a/mobile_cv/arch/fbnet_v2/blocks_factory.py
+++ b/mobile_cv/arch/fbnet_v2/blocks_factory.py
@@ -23,22 +23,36 @@ PRIMITIVES = registry.Registry("blocks_factory")
 
 _PRIMITIVES = {
     "noop": lambda in_channels, out_channels, stride, **kwargs: bb.TorchNoOp(),
-    "unsqueeze": lambda in_channels, out_channels, stride, dim, **kwargs: bb.TorchUnsqueeze(
-        dim
-    ),
+    "unsqueeze": lambda in_channels,
+    out_channels,
+    stride,
+    dim,
+    **kwargs: bb.TorchUnsqueeze(dim),
     "upsample": lambda in_channels, out_channels, stride, **kwargs: bb.Upsample(
         scale_factor=stride, mode="nearest"
     ),
-    "downsample": lambda in_channels, out_channels, stride, mode="bicubic", **kwargs: bb.Upsample(  # noqa
+    "downsample": lambda in_channels,
+    out_channels,
+    stride,
+    mode="bicubic",
+    **kwargs: bb.Upsample(  # noqa
         scale_factor=(1.0 / stride), mode=mode
     ),
-    "dc_k3": lambda in_channels, out_channels, stride, **kwargs: irf_block.DepthConvBNRelu(
+    "dc_k3": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.DepthConvBNRelu(
         in_channels, out_channels, kernel_size=3, stride=stride, **kwargs
     ),
     "skip": lambda in_channels, out_channels, stride, **kwargs: bb.Identity(
         in_channels, out_channels, stride
     ),
-    "maxpool": lambda in_channels, out_channels, stride, kernel_size=3, padding=0, **kwargs: nn.MaxPool2d(  # noqa
+    "maxpool": lambda in_channels,
+    out_channels,
+    stride,
+    kernel_size=3,
+    padding=0,
+    **kwargs: nn.MaxPool2d(  # noqa
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
@@ -52,7 +66,10 @@ _PRIMITIVES = {
             kwargs=kwargs,
         ),
     ),
-    "res_block_k3": lambda in_channels, out_channels, stride, **kwargs: res_block.Bottleneck(
+    "res_block_k3": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: res_block.Bottleneck(
         in_channels,
         out_channels,
         **hp.merge(
@@ -60,7 +77,10 @@ _PRIMITIVES = {
             kwargs=kwargs,
         ),
     ),
-    "res_block_3D_k133": lambda in_channels, out_channels, stride, **kwargs: res_block.Bottleneck(
+    "res_block_3D_k133": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: res_block.Bottleneck(
         in_channels,
         out_channels,
         **hp.merge(
@@ -73,7 +93,10 @@ _PRIMITIVES = {
             kwargs=kwargs,
         ),
     ),
-    "res_block_3D_k155": lambda in_channels, out_channels, stride, **kwargs: res_block.Bottleneck(
+    "res_block_3D_k155": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: res_block.Bottleneck(
         in_channels,
         out_channels,
         **hp.merge(
@@ -107,7 +130,10 @@ _PRIMITIVES = {
             kwargs=kwargs,
         ),
     ),
-    "aa_conv_k3": lambda in_channels, out_channels, stride, **kwargs: bb.antialiased_conv_bn_relu(
+    "aa_conv_k3": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: bb.antialiased_conv_bn_relu(
         in_channels,
         out_channels,
         **hp.merge(
@@ -136,13 +162,22 @@ _PRIMITIVES = {
             kwargs=kwargs,
         ),
     ),
-    "avgpool": lambda in_channels, out_channels, stride, kernel_size=2, padding=0, **kwargs: nn.AvgPool2d(  # noqa
+    "avgpool": lambda in_channels,
+    out_channels,
+    stride,
+    kernel_size=2,
+    padding=0,
+    **kwargs: nn.AvgPool2d(  # noqa
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
         **hp.filter_kwargs(func=nn.AvgPool2d, kwargs=kwargs),
     ),
-    "adaptive_avg_pool": lambda in_channels, out_channels, stride, output_size, **kwargs: nn.AdaptiveAvgPool2d(  # noqa
+    "adaptive_avg_pool": lambda in_channels,
+    out_channels,
+    stride,
+    output_size,
+    **kwargs: nn.AdaptiveAvgPool2d(  # noqa
         output_size=output_size,
         **hp.filter_kwargs(func=nn.AdaptiveAvgPool2d, kwargs=kwargs),
     ),
@@ -231,7 +266,10 @@ _PRIMITIVES = {
     "ir_k5_se": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRFBlock(
         in_channels, out_channels, stride=stride, kernel_size=5, se_args="se", **kwargs
     ),
-    "ir_k3_sehsig": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRFBlock(  # noqa
+    "ir_k3_sehsig": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRFBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
@@ -239,7 +277,10 @@ _PRIMITIVES = {
         se_args="se_hsig",
         **kwargs,
     ),
-    "ir_k5_sehsig": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRFBlock(  # noqa
+    "ir_k5_sehsig": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRFBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
@@ -247,7 +288,10 @@ _PRIMITIVES = {
         se_args="se_hsig",
         **kwargs,
     ),
-    "ir_k3_sehsig_hs": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRFBlock(  # noqa
+    "ir_k3_sehsig_hs": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRFBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
@@ -256,7 +300,10 @@ _PRIMITIVES = {
         se_args="se_hsig",
         **kwargs,
     ),
-    "ir_k5_sehsig_hs": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRFBlock(  # noqa
+    "ir_k5_sehsig_hs": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRFBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
@@ -265,20 +312,29 @@ _PRIMITIVES = {
         se_args="se_hsig",
         **kwargs,
     ),
-    "ir_pool": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRPoolBlock(  # noqa
+    "ir_pool": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRPoolBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
         **hp.filter_kwargs(irf_block.IRPoolBlock, kwargs),
     ),
-    "ir_pool_hs": lambda in_channels, out_channels, stride, **kwargs: irf_block.IRPoolBlock(  # noqa
+    "ir_pool_hs": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: irf_block.IRPoolBlock(  # noqa
         in_channels,
         out_channels,
         stride=stride,
         relu_args="hswish",
         **hp.filter_kwargs(irf_block.IRPoolBlock, kwargs),
     ),
-    "mobileone": lambda in_channels, out_channels, stride, **kwargs: mobileone_block.MobileOneBlock(
+    "mobileone": lambda in_channels,
+    out_channels,
+    stride,
+    **kwargs: mobileone_block.MobileOneBlock(
         in_channels,
         out_channels,
         stride=stride,

--- a/mobile_cv/arch/fbnet_v2/gb_block.py
+++ b/mobile_cv/arch/fbnet_v2/gb_block.py
@@ -5,7 +5,6 @@
 GhostNet: More Features from Cheap Operations
 """
 
-
 import math
 
 import mobile_cv.arch.utils.helper as hp

--- a/mobile_cv/arch/fbnet_v2/mobileone_block.py
+++ b/mobile_cv/arch/fbnet_v2/mobileone_block.py
@@ -5,7 +5,6 @@
 An Improved One millisecond Mobile Backbone (https://arxiv.org/abs/2206.04040)
 """
 
-
 import mobile_cv.arch.utils.helper as hp
 import torch.nn as nn
 

--- a/mobile_cv/arch/fbnet_v2/modeldef_registry.py
+++ b/mobile_cv/arch/fbnet_v2/modeldef_registry.py
@@ -5,7 +5,6 @@ import copy
 
 
 class FBNetV2ModelArch(object):
-
     _MODEL_ARCH = {}
 
     @staticmethod

--- a/mobile_cv/arch/fbnet_v2/norms.py
+++ b/mobile_cv/arch/fbnet_v2/norms.py
@@ -40,16 +40,18 @@ class adaILN(nn.Module):
     def forward(self, data: Tuple[torch.Tensor, torch.Tensor]):
         x, style = data
 
-        in_mean, in_var = torch.mean(x, dim=[2, 3], keepdim=True), torch.var(
-            x, dim=[2, 3], keepdim=True
+        in_mean, in_var = (
+            torch.mean(x, dim=[2, 3], keepdim=True),
+            torch.var(x, dim=[2, 3], keepdim=True),
         )
         # out_in = (x - in_mean) / torch.sqrt(in_var + self.eps)
         out_in = self.mul(
             self.add(x, self.mul_neg(in_mean)), torch.rsqrt(self.add_eps(in_var))
         )
 
-        ln_mean, ln_var = torch.mean(x, dim=[1, 2, 3], keepdim=True), torch.var(
-            x, dim=[1, 2, 3], keepdim=True
+        ln_mean, ln_var = (
+            torch.mean(x, dim=[1, 2, 3], keepdim=True),
+            torch.var(x, dim=[1, 2, 3], keepdim=True),
         )
         # out_ln = (x - ln_mean) / torch.sqrt(ln_var + self.eps)
         out_ln = self.mul(
@@ -91,16 +93,18 @@ class ILN(nn.Module):
         # todo: wrapper for torch.rsqrt ?
 
     def forward(self, x):
-        in_mean, in_var = torch.mean(x, dim=[2, 3], keepdim=True), torch.var(
-            x, dim=[2, 3], keepdim=True
+        in_mean, in_var = (
+            torch.mean(x, dim=[2, 3], keepdim=True),
+            torch.var(x, dim=[2, 3], keepdim=True),
         )
         # out_in = (x - in_mean) * torch.rsqrt(self.add_eps(in_var))
         out_in = self.mul(
             self.add(x, self.mul_neg(in_mean)), torch.rsqrt(self.add_eps(in_var))
         )
 
-        ln_mean, ln_var = torch.mean(x, dim=[1, 2, 3], keepdim=True), torch.var(
-            x, dim=[1, 2, 3], keepdim=True
+        ln_mean, ln_var = (
+            torch.mean(x, dim=[1, 2, 3], keepdim=True),
+            torch.var(x, dim=[1, 2, 3], keepdim=True),
         )
         # out_ln = (x - ln_mean) / torch.sqrt(ln_var + self.eps)
         out_ln = self.mul(

--- a/mobile_cv/arch/tests/test_builder_meta_builder.py
+++ b/mobile_cv/arch/tests/test_builder_meta_builder.py
@@ -88,10 +88,16 @@ class TestFBNetBuilder(unittest.TestCase):
 
         blocks_factory.PRIMITIVES.register_dict(
             {
-                "conv_check": lambda in_channels, out_channels, stride, **kwargs: ConvCheck(  # noqa
+                "conv_check": lambda in_channels,
+                out_channels,
+                stride,
+                **kwargs: ConvCheck(  # noqa
                     in_channels, out_channels, stride=stride, **kwargs
                 ),
-                "irf_check": lambda in_channels, out_channels, stride, **kwargs: IRFCheck(  # noqa
+                "irf_check": lambda in_channels,
+                out_channels,
+                stride,
+                **kwargs: IRFCheck(  # noqa
                     in_channels, out_channels, stride=stride, **kwargs
                 ),
             }

--- a/mobile_cv/arch/tests/test_utils_quantize_utils.py
+++ b/mobile_cv/arch/tests/test_utils_quantize_utils.py
@@ -208,7 +208,6 @@ class TestUtilsQuantizeUtils(unittest.TestCase):
         self.assertEqual(output2["m3"], 4.0)
 
     def test_utils_quantize_utils_quantizable_module(self):
-
         with mock.patch("mobile_cv.arch.utils.quantize_utils.QuantStub.forward") as qs:
             with mock.patch(
                 "mobile_cv.arch.utils.quantize_utils.DeQuantStub.forward"
@@ -290,7 +289,6 @@ class TestUtilsQuantizeUtils(unittest.TestCase):
         self.assertEqual(len(outputs1), 2)
 
     def test_quant_warpper_with_kwargs(self):
-
         model = TestModule()
         input1 = torch.ones((1,))
         input2 = torch.ones((1,))

--- a/mobile_cv/common/misc/py.py
+++ b/mobile_cv/common/misc/py.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-""" python utils """
+"""python utils"""
 
 import glob
 import logging
@@ -117,7 +117,6 @@ class FolderLock:
 
 # https://stackoverflow.com/questions/4716533/how-to-attach-debugger-to-a-python-subproccess  # noqa
 class MultiprocessingPdb(pdb.Pdb):
-
     _stdin_fd = sys.stdin.fileno()
     _stdin = None
 

--- a/mobile_cv/common/tests/test_local_cache.py
+++ b/mobile_cv/common/tests/test_local_cache.py
@@ -42,7 +42,6 @@ def func_unique(cache_dir, index, total_processes, iter, shards):
 
 
 def test_cache(self, test_func, num_procs, iter, shards=1, **kwargs):
-
     with tempfile.TemporaryDirectory() as tmpdir:
         if num_procs == 0:
             test_func(

--- a/mobile_cv/lut/lib/lut_ops.py
+++ b/mobile_cv/lut/lib/lut_ops.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 
-""" Represents ops in LUT, following pytorch's interface """
+"""Represents ops in LUT, following pytorch's interface"""
 
 import functools
 import json
@@ -545,12 +545,7 @@ class MultiheadAttention(OpProperty):
         assert S == vs[0]
 
         flops = N * (
-            L * E * E
-            + S * K * E
-            + S * V * E
-            + L * E * S
-            + L * S * E
-            + L * E * E
+            L * E * E + S * K * E + S * V * E + L * E * S + L * S * E + L * E * E
             # -------    ---------   ---------   ---------   ---------   ---------
             # Q_proj    K_proj      V_proj      Q * K       (QK) * V    out_proj
         )

--- a/mobile_cv/model_zoo/models/model_torchvision.py
+++ b/mobile_cv/model_zoo/models/model_torchvision.py
@@ -5,7 +5,6 @@
 Models from torchvision, providing the same interface for loading in model zoo
 """
 
-
 import torchvision
 
 # to register for model_zoo

--- a/mobile_cv/model_zoo/tests/test_tools_create_model.py
+++ b/mobile_cv/model_zoo/tests/test_tools_create_model.py
@@ -83,7 +83,10 @@ class TestModelZooToolsCreateModel(unittest.TestCase):
 
         blocks_factory.PRIMITIVES.register_dict(
             {
-                "cached_plus": lambda in_channels, out_channels, stride, **kwargs: CachedPlus()
+                "cached_plus": lambda in_channels,
+                out_channels,
+                stride,
+                **kwargs: CachedPlus()
             }
         )
         arch = {

--- a/mobile_cv/model_zoo/tests/test_tools_model_exporter.py
+++ b/mobile_cv/model_zoo/tests/test_tools_model_exporter.py
@@ -289,9 +289,10 @@ class TestToolsModelExporter(unittest.TestCase):
     def test_tools_model_exporter_fx_quant(self):
         blocks_factory.PRIMITIVES.register_dict(
             {
-                "exporter_fx_quant_test": lambda in_channels, out_channels, stride, **kwargs: TestModel(
-                    num=2
-                )
+                "exporter_fx_quant_test": lambda in_channels,
+                out_channels,
+                stride,
+                **kwargs: TestModel(num=2)
             }
         )
         arch = {"blocks": [[("exporter_fx_quant_test", 1, 1, 1)]]}

--- a/mobile_cv/predictor/model_wrappers.py
+++ b/mobile_cv/predictor/model_wrappers.py
@@ -105,8 +105,8 @@ class Caffe2Wrapper(nn.Module):
         return output_devices
 
     def forward(self, inputs):
-        assert len(inputs) == len(
-            self._input_blobs
+        assert (
+            len(inputs) == len(self._input_blobs)
         ), "Number of input tensors ({}) doesn't match the required input blobs: {}".format(
             len(inputs), self._input_blobs
         )

--- a/mobile_cv/torch/utils_pytorch/comm.py
+++ b/mobile_cv/torch/utils_pytorch/comm.py
@@ -3,6 +3,7 @@
 This file contains primitives for multi-gpu communication.
 This is useful when doing distributed training.
 """
+
 import functools
 from typing import Optional
 

--- a/mobile_cv/torch/utils_pytorch/state_dict_name_matcher.py
+++ b/mobile_cv/torch/utils_pytorch/state_dict_name_matcher.py
@@ -18,8 +18,8 @@ def get_state_dict_name_mapping(
     """
     m1_state_dict_shapes = {k: v.shape for k, v in model1_state_dict.items()}
     m2_state_dict_shapes = {k: v.shape for k, v in model2_state_dict.items()}
-    assert len(m1_state_dict_shapes) == len(
-        m2_state_dict_shapes
+    assert (
+        len(m1_state_dict_shapes) == len(m2_state_dict_shapes)
     ), f"m1_state_dict_shapes: {m1_state_dict_shapes}, \n m2_state_dict_shapes {m2_state_dict_shapes}"
 
     ret = get_matching(m1_state_dict_shapes, m2_state_dict_shapes)


### PR DESCRIPTION
Summary:
Converts the directory specified to use the Ruff formatter in pyfmt

ruff_dog

If this diff causes merge conflicts when rebasing, please run
`hg status -n -0 --change . -I '**/*.{py,pyi}' | xargs -0 arc pyfmt`
on your diff, and amend any changes before rebasing onto latest.
That should help reduce or eliminate any merge conflicts.

allow-large-files

Reviewed By: zertosh

Differential Revision: D62971745
