### PR TITLE
Support batch_first for MultiheadAttention

### DIFF
--- a/mobile_cv/lut/lib/pt/pt_converter.py
+++ b/mobile_cv/lut/lib/pt/pt_converter.py
@@ -149,6 +149,7 @@ def convert_MultiheadAttention(m, input_shapes):
         m.num_heads,
         kdim=m.kdim,
         vdim=m.vdim,
+        batch_first=m.batch_first,
     )
     ret = lut_schema.OpInfo(op, input_shapes)
     return ret


### PR DESCRIPTION
Summary:
- `nn.MultiheadAttention` has `batch_first` attribute, which defaults to False; however, if `batch_first` is set to True, the current flop calculation will be wrong.
  - It may impact the calculation for all transformer modules when `batch_first=True`.
  - When q, k, v have the same dimensions, the issue may not reveal easily by itself, but when q has a different seq length than k and v, the assertion fails:
{F1982119190}

- Now extract the correct input shape dimensions when `batch_first` is True.

Differential Revision: D82797729


