### PR TITLE
ImageFont.getsize -> getbbox

### DIFF
--- a/mobile_cv/common/misc/visualize_utils.py
+++ b/mobile_cv/common/misc/visualize_utils.py
@@ -239,7 +239,8 @@ def draw_image_grid(
 
             # Draw the label below the image
             if label is not None:
-                label_width, label_height = label_font.getsize(label)
+                label_left, _, label_right, _ = label_font.getbbox(label)
+                label_width = label_right - label_left
                 label_x = (
                     image_x + (width_per_column[col] - label_width) // 2
                 )  # Center horizontally
@@ -249,7 +250,10 @@ def draw_image_grid(
 
             # Draw the image title above the image
             if image_title is not None:
-                image_title_width, image_title_height = title_font.getsize(image_title)
+                image_title_left, _, image_title_right, _ = title_font.getbbox(
+                    image_title
+                )
+                image_title_width = image_title_right - image_title_left
                 image_title_x = (
                     image_x + (width_per_column[col] - image_title_width) // 2
                 )  # Center horizontally


### PR DESCRIPTION
Summary: Pillow 10 removed the public `ImageFont.getsize` (the built 10.4.0 wheel raises `AttributeError`). Here we replace two call sites to enable upgrading Pillow to 10.4/11.3/12.2

Reviewed By: fried

Differential Revision: D108633404


