### PR TITLE
mobile-vision: flip pillow 9.4.0 -> 12.2.0

### DIFF
--- a/mobile_cv/common/misc/visualize_utils.py
+++ b/mobile_cv/common/misc/visualize_utils.py
@@ -178,7 +178,9 @@ def draw_image_grid(
                 cur = Image.open(fp)
                 cur.load()
             if max_image_size is not None:
-                cur.thumbnail((max_image_size, max_image_size), Image.LANCZOS)
+                cur.thumbnail(
+                    (max_image_size, max_image_size), Image.Resampling.LANCZOS
+                )
         images.append(cur)
 
     # Get the dimensions of the images to create the grid


### PR DESCRIPTION
Summary: Flips the `pypi/pillow` pin from 9.4.0 to the repo default 12.2.0 for `fbcode/mobile-vision/`, part of the Pillow default-flip enablement (T274839644). Pure pin flip; no code changes required.

Reviewed By: itamaro

Differential Revision: D112184016


